### PR TITLE
Remove video indicator and related JS

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,10 +44,6 @@
       </div>
     </header>
 
-    <!-- Індикатор -->
-    <div id="video-indicator" class="absolute bottom-6 left-6 text-white text-sm tracking-widest z-20">
-      01 / 024
-    </div>
   </section>
 
   <!-- JS -->

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,4 @@
 const videoElement = document.getElementById("bg-video");
-const indicator = document.getElementById("video-indicator");
 
 // Масив відео
 const videos = [
@@ -39,12 +38,6 @@ function playRandomVideo() {
 
     videoElement.classList.remove("opacity-0");
     videoElement.classList.add("opacity-100");
-
-    // Індикатор
-    indicator.innerHTML = `
-      <div>${(currentIndex+1).toString().padStart(2, '0')} / ${videos.length}</div>
-      <div class="text-xs text-gray-300">${currentVideo.code}</div>
-    `;
 
     setTimeout(() => {
       videoElement.classList.remove("opacity-100");


### PR DESCRIPTION
## Summary
- Remove the video-indicator markup from the main page
- Drop indicator lookup and update logic from JavaScript

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0732dd3108324a00e129fc7eb8564