### PR TITLE
Remove video indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,10 +44,6 @@
       </div>
     </header>
 
-    <!-- Індикатор -->
-    <div id="video-indicator" class="absolute bottom-6 left-6 text-white text-sm tracking-widest z-20">
-      01 / 024
-    </div>
   </section>
 
   <!-- JS -->

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,4 @@
 const videoElement = document.getElementById("bg-video");
-const indicator = document.getElementById("video-indicator");
 
 // Масив відео
 const videos = [
@@ -40,11 +39,6 @@ function playRandomVideo() {
     videoElement.classList.remove("opacity-0");
     videoElement.classList.add("opacity-100");
 
-    // Індикатор
-    indicator.innerHTML = `
-      <div>${(currentIndex+1).toString().padStart(2, '0')} / ${videos.length}</div>
-      <div class="text-xs text-gray-300">${currentVideo.code}</div>
-    `;
 
     setTimeout(() => {
       videoElement.classList.remove("opacity-100");


### PR DESCRIPTION
## Summary
- remove the video indicator element from the landing page
- strip JS that updated the removed indicator

## Testing
- `node test.js` *(fails: Failed to load resource errors due to missing assets)*

------
https://chatgpt.com/codex/tasks/task_e_68c152ddc05c8324a514f6a929a34cd2