### PR TITLE
Add directional strip transitions for background video

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,57 +1,65 @@
-const videoElement = document.getElementById("bg-video");
-const indicator = document.getElementById("video-indicator");
+/* Transition strip styles and animations */
 
-// Масив відео
-const videos = [
-  { src: "video/intro-1.mp4", code: "intro-1" },
-  { src: "video/intro-2.mp4", code: "intro-2" },
-  { src: "video/intro-3.mp4", code: "intro-3" },
-  { src: "video/intro-4.mp4", code: "intro-4" }
-];
-
-let currentIndex = -1;
-
-function playRandomVideo() {
-  let newIndex;
-  do {
-    newIndex = Math.floor(Math.random() * videos.length);
-  } while (newIndex === currentIndex);
-
-  currentIndex = newIndex;
-  const currentVideo = videos[currentIndex];
-
-  const tempVideo = document.createElement("video");
-  tempVideo.src = currentVideo.src;
-
-  tempVideo.onloadedmetadata = () => {
-    const duration = tempVideo.duration;
-
-    // Якщо відео коротше 2 секунд – пропускаємо
-    if (duration <= 2) {
-      playRandomVideo();
-      return;
-    }
-
-    const randomStart = Math.random() * (duration - 2);
-
-    videoElement.src = currentVideo.src;
-    videoElement.currentTime = randomStart;
-
-    videoElement.classList.remove("opacity-0");
-    videoElement.classList.add("opacity-100");
-
-    // Індикатор
-    indicator.innerHTML = `
-      <div>${(currentIndex+1).toString().padStart(2, '0')} / ${videos.length}</div>
-      <div class="text-xs text-gray-300">${currentVideo.code}</div>
-    `;
-
-    setTimeout(() => {
-      videoElement.classList.remove("opacity-100");
-      videoElement.classList.add("opacity-0");
-      setTimeout(playRandomVideo, 1000);
-    }, 2000);
-  };
+.strip {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #000;
+  z-index: 15;
+  display: none;
+  pointer-events: none;
 }
 
-playRandomVideo();
+.strip.up {
+  display: block;
+  animation: slide-up 1s forwards;
+}
+
+.strip.down {
+  display: block;
+  animation: slide-down 1s forwards;
+}
+
+.strip.diagonal {
+  display: block;
+  animation: slide-diagonal 1s forwards;
+}
+
+@keyframes slide-up {
+  0% {
+    transform: translateY(100%);
+  }
+  50% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(-100%);
+  }
+}
+
+@keyframes slide-down {
+  0% {
+    transform: translateY(-100%);
+  }
+  50% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(100%);
+  }
+}
+
+@keyframes slide-diagonal {
+  0% {
+    transform: translate(-100%, 100%);
+  }
+  50% {
+    transform: translate(0, 0);
+  }
+  100% {
+    transform: translate(100%, -100%);
+  }
+}
+

--- a/index.html
+++ b/index.html
@@ -26,6 +26,9 @@
     <video id="bg-video" autoplay muted playsinline
       class="absolute top-0 left-0 w-full h-full object-cover opacity-0 transition-opacity duration-1000"></video>
 
+    <!-- Смуга для переходів -->
+    <div class="strip"></div>
+
     <!-- Затемнення -->
     <div class="absolute inset-0 bg-black/40 z-10"></div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,5 @@
 const videoElement = document.getElementById("bg-video");
+const strip = document.querySelector(".strip");
 
 // Масив відео
 const videos = [
@@ -35,17 +36,37 @@ function playRandomVideo() {
 
     videoElement.src = currentVideo.src;
     videoElement.currentTime = randomStart;
-
     videoElement.classList.remove("opacity-0");
     videoElement.classList.add("opacity-100");
-
-
-    setTimeout(() => {
-      videoElement.classList.remove("opacity-100");
-      videoElement.classList.add("opacity-0");
-      setTimeout(playRandomVideo, 1000);
-    }, 2000);
+    videoElement.play();
   };
 }
 
+const directions = ["up", "down", "diagonal"];
+const animationDuration = 1000; // ms
+
+function startTransition() {
+  const dir = directions[Math.floor(Math.random() * directions.length)];
+  strip.classList.add(dir);
+
+  setTimeout(() => {
+    playRandomVideo();
+  }, animationDuration / 2);
+
+  strip.addEventListener(
+    "animationend",
+    () => {
+      strip.className = "strip";
+      scheduleNext();
+    },
+    { once: true }
+  );
+}
+
+function scheduleNext() {
+  setTimeout(startTransition, 2000);
+}
+
 playRandomVideo();
+scheduleNext();
+


### PR DESCRIPTION
## Summary
- overlay `<div class="strip">` above the background video to support animated transitions
- add CSS animations for up, down, and diagonal strip wipes
- update JS to trigger direction-specific strip animations when switching videos

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c16215fb788324be57ddea04d12a3d